### PR TITLE
Add SQL playground with Groq-powered query explanations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # coquery
-Querying with Copilots
+
+CoQuery is a minimal SQL playground powered by SQLite WASM and Groq
+language models.  It ships with two sample databases (Chinook and
+AdventureWorks) and exposes four actions:
+
+* **Execute** – run the current SQL against the selected database.
+* **Explain** – send the SQL to a Groq model for a natural‑language
+  explanation.
+* **Decompose & Verify** – ask Groq to break the query into logical
+  steps and verify each part.
+* **Clear** – reset the results and agent output.
+
+## Running
+
+Open `index.html` in a browser.  Supply your `groq_api_key` in the text
+box to enable the explain/decompose features.  Queries are executed in
+browser using the bundled SQLite databases from the `data/` directory.
+
+The interface uses CodeMirror for SQL editing and `sql.js` for the WASM
+SQLite engine.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>CoQuery: Querying with Copilots</title>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/codemirror.min.css" integrity="sha512-7kRAKXc+yEiZVqtl4YZ93k9VtzfNZt7QSboPbbGr3HdWu3UwG+329xNXm/SuKD5Vac/mswHxZ34rnOG0r8QwOw==" crossorigin="anonymous" referrerpolicy="no-referrer"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/theme/eclipse.min.css" integrity="sha512-xcmBHQYaWV7k/akdUSHh3DquynjUTduVdJN9WewtG/XAIN5e8wZsM+dAf5BgU984wgKLF6ig84yYI6FqdtYYBQ==" crossorigin="anonymous" referrerpolicy="no-referrer"/>
+<style>
+ body { font-family: sans-serif; margin: 20px; }
+ #sql { height: 200px; border: 1px solid #ccc; }
+ #agent { width: 100%; height: 150px; }
+ #results { margin-top: 10px; }
+ table { border-collapse: collapse; }
+ th, td { border: 1px solid #ccc; padding: 4px; }
+ .controls { margin-top: 10px; }
+</style>
+</head>
+<body>
+<h1>CoQuery: Querying with Copilots</h1>
+<div>
+<label for="dbSelect">Database:</label>
+<select id="dbSelect">
+<option value="Chinook_Sqlite.sqlite">Chinook</option>
+<option value="AdventureWorks-sqlite.db">AdventureWorks</option>
+</select>
+<input type="text" id="apiKey" placeholder="Groq API Key" />
+</div>
+<textarea id="agent" placeholder="Agent responses appear here..."></textarea>
+<div id="sql"></div>
+<div class="controls">
+<button id="executeBtn">Execute</button>
+<button id="explainBtn">Explain</button>
+<button id="decomposeBtn">Decompose & Verify</button>
+<button id="clearBtn">Clear</button>
+</div>
+<div id="results"></div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/codemirror.min.js" integrity="sha512-k0MyoVo9hw3rroWAt4EvsC0BpvyEukgqS0bkkCm1cW0XkyRjO6jwxKF1u9IiMaivGi99ZTSdKCbFf8gDuwZDow==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/mode/sql/sql.min.js" integrity="sha512-PxfrN7kYMva9n32CuWHa3gwxObn2ymlk/wEYBLETymFcpnSUsctNk6heAQ7Ez+KQEiC5EvhczHxVn9Yx8RJWbQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script type="module" src="./script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,102 @@
+import { Groq } from "https://esm.sh/groq-sdk";
+import initSqlJs from "https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.8.0/sql-wasm.js";
+
+let db; // sql.js database
+let editor; // CodeMirror instance
+let groq; // Groq client
+
+async function init() {
+  // initialize CodeMirror
+  editor = CodeMirror(document.getElementById('sql'), {
+    mode: 'text/x-sql',
+    theme: 'eclipse',
+    lineNumbers: true,
+    value: 'SELECT 1;'
+  });
+
+  // load sql.js
+  const SQL = await initSqlJs({ locateFile: file => `https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.8.0/${file}` });
+
+  // load default DB
+  await loadDb(document.getElementById('dbSelect').value, SQL);
+
+  document.getElementById('dbSelect').addEventListener('change', async (e) => {
+    await loadDb(e.target.value, SQL);
+  });
+
+  document.getElementById('executeBtn').addEventListener('click', executeQuery);
+  document.getElementById('explainBtn').addEventListener('click', () => explainQuery('explain this sql query and break it down into components:'));
+  document.getElementById('decomposeBtn').addEventListener('click', () => explainQuery('decompose this sql query into parts and verify each step:'));
+  document.getElementById('clearBtn').addEventListener('click', () => {
+    document.getElementById('agent').value = '';
+    document.getElementById('results').innerHTML = '';
+  });
+}
+
+async function loadDb(path, SQL) {
+  const res = await fetch(`data/${path}`);
+  const buf = await res.arrayBuffer();
+  db = new SQL.Database(new Uint8Array(buf));
+}
+
+function executeQuery() {
+  const sql = editor.getValue();
+  try {
+    const res = db.exec(sql);
+    const container = document.getElementById('results');
+    container.innerHTML = '';
+    res.forEach(({columns, values}) => {
+      const table = document.createElement('table');
+      const thead = document.createElement('thead');
+      const trHead = document.createElement('tr');
+      columns.forEach(col => {
+        const th = document.createElement('th');
+        th.textContent = col;
+        trHead.appendChild(th);
+      });
+      thead.appendChild(trHead);
+      table.appendChild(thead);
+      const tbody = document.createElement('tbody');
+      values.forEach(row => {
+        const tr = document.createElement('tr');
+        row.forEach(val => {
+          const td = document.createElement('td');
+          td.textContent = val;
+          tr.appendChild(td);
+        });
+        tbody.appendChild(tr);
+      });
+      table.appendChild(tbody);
+      container.appendChild(table);
+    });
+  } catch (e) {
+    document.getElementById('results').textContent = e.message;
+  }
+}
+
+async function explainQuery(prompt) {
+  const sql = editor.getValue();
+  const key = document.getElementById('apiKey').value;
+  if (!key) {
+    alert('Please provide a Groq API key.');
+    return;
+  }
+  if (!groq) {
+    groq = new Groq({ apiKey: key });
+  }
+  const chatCompletion = await groq.chat.completions.create({
+    messages: [
+      { role: 'user', content: `${prompt}\n\n${sql}` }
+    ],
+    model: 'openai/gpt-oss-20b',
+    temperature: 1,
+    max_completion_tokens: 1024,
+    top_p: 1,
+    stream: false
+  });
+  const text = chatCompletion.choices?.[0]?.message?.content || '';
+  const agentBox = document.getElementById('agent');
+  agentBox.value += `\n${text}`;
+}
+
+init();


### PR DESCRIPTION
## Summary
- add browser-based SQL IDE using CodeMirror and `sql.js`
- support executing queries against bundled Chinook and AdventureWorks databases
- integrate Groq API for query explanation and decomposition

## Testing
- `npm test` *(fails: ENOENT package.json)*


------
https://chatgpt.com/codex/tasks/task_e_689cf5bda210832e806dc3e8c5c959d1