### PR TITLE
Ensure LLM SQL appears in editor and improve history button visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,10 +152,10 @@
                                     SQL Query
                                 </h3>
                                 <div class="card-actions">
-                                    <button id="prevQueryBtn" class="btn btn-sm btn-light" type="button">
+                                    <button id="prevQueryBtn" class="btn btn-sm btn-outline-secondary" type="button">
                                         <i class="ti ti-chevron-left"></i>
                                     </button>
-                                    <button id="nextQueryBtn" class="btn btn-sm btn-light" type="button">
+                                    <button id="nextQueryBtn" class="btn btn-sm btn-outline-secondary" type="button">
                                         <i class="ti ti-chevron-right"></i>
                                     </button>
                                 </div>

--- a/script.js
+++ b/script.js
@@ -694,7 +694,7 @@ ORDER BY
                 this.editor.setValue(newSql);
                 this.flashEditor();
                 this.addToHistory(newSql);
-                this.updateAgentResponse(`Here is the updated SQL query:\n\n\`\`\`sql\n${newSql}\n\`\`\``);
+                this.updateAgentResponse('SQL inserted into editor.');
             } else {
                 this.updateAgentResponse('No SQL generated.');
             }


### PR DESCRIPTION
## Summary
- Render SQL generated by NL2SQL directly in the editor instead of the LLM output widget
- Style query history navigation buttons in grey for better contrast on light backgrounds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f914ddff4832eac182af9ed93493e