### PR TITLE
Update explain button to use theme success color

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@
                                 <i class="ti ti-play"></i>
                                 Execute
                             </button>
-                            <button id="explainBtn" class="btn btn-secondary">
+                            <button id="explainBtn" class="btn btn-success">
                                 <i class="ti ti-info-circle"></i>
                                 Explain
                             </button>


### PR DESCRIPTION
## Summary
- switch the Explain button to the Tabler success style so it appears in the theme's green color

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cc46c00dd0832e8926e86871a34e8e